### PR TITLE
Delete unused apis 2

### DIFF
--- a/backend/account/serializers.py
+++ b/backend/account/serializers.py
@@ -131,10 +131,6 @@ class SSOSerializer(serializers.Serializer):
     token = serializers.CharField()
 
 
-class TwoFactorAuthCodeSerializer(serializers.Serializer):
-    code = serializers.IntegerField()
-
-
 class ImageUploadForm(forms.Form):
     image = forms.FileField()
 

--- a/backend/account/tests.py
+++ b/backend/account/tests.py
@@ -235,6 +235,7 @@ class UserRegisterAPITest(CaptchaTest):
         response = self.client.post(self.register_url, data=self.data)
         self.assertDictEqual(response.data, {"error": "error", "data": "Email already exists"})
 
+
 class SessionManagementAPITest(APITestCase):
     def setUp(self):
         self.create_user("2020222000", "test123")
@@ -256,6 +257,7 @@ class SessionManagementAPITest(APITestCase):
     def test_delete_session_with_invalid_key(self):
         resp = self.client.delete(self.url + "?session_key=aaaaaaaaaa")
         self.assertDictEqual(resp.data, {"error": "error", "data": "Invalid session_key"})
+
 
 class UserProfileAPITest(APITestCase):
     def setUp(self):

--- a/backend/account/tests.py
+++ b/backend/account/tests.py
@@ -218,29 +218,6 @@ class UserRegisterAPITest(CaptchaTest):
         self.assertDictEqual(response.data, {"error": "error", "data": "Email already exists"})
 
 
-class SessionManagementAPITest(APITestCase):
-    def setUp(self):
-        self.create_user("2020222000", "test123")
-        self.url = self.reverse("session_management_api")
-        # launch a request to provide session data
-        login_url = self.reverse("user_login_api")
-        self.client.post(login_url, data={"username": "test", "password": "test123"})
-
-    def test_get_sessions(self):
-        resp = self.client.get(self.url)
-        self.assertSuccess(resp)
-        data = resp.data["data"]
-        self.assertEqual(len(data), 1)
-
-    # def test_delete_session_key(self):
-    #     resp = self.client.delete(self.url + "?session_key=" + self.session_key)
-    #     self.assertSuccess(resp)
-
-    def test_delete_session_with_invalid_key(self):
-        resp = self.client.delete(self.url + "?session_key=aaaaaaaaaa")
-        self.assertDictEqual(resp.data, {"error": "error", "data": "Invalid session_key"})
-
-
 class UserProfileAPITest(APITestCase):
     def setUp(self):
         self.url = self.reverse("user_profile_api")

--- a/backend/account/tests.py
+++ b/backend/account/tests.py
@@ -83,24 +83,6 @@ class WrongFormatUserCheckAPITest(APITestCase):
         self.assertEqual(resp.data["data"]["email"], 2)
 
 
-class TFARequiredCheckAPITest(APITestCase):
-    def setUp(self):
-        self.url = self.reverse("tfa_required_check")
-        self.create_user("2020222000", "test123", login=False)
-
-    def test_not_required_tfa(self):
-        resp = self.client.post(self.url, data={"username": "test"})
-        self.assertSuccess(resp)
-        self.assertEqual(resp.data["data"]["result"], False)
-
-    def test_required_tfa(self):
-        user = User.objects.first()
-        user.two_factor_auth = True
-        user.save()
-        resp = self.client.post(self.url, data={"username": "2020222000"})
-        self.assertEqual(resp.data["data"]["result"], True)
-
-
 class UserLoginAPITest(APITestCase):
     def setUp(self):
         self.username = self.password = "2020222000"

--- a/backend/account/tests.py
+++ b/backend/account/tests.py
@@ -235,6 +235,27 @@ class UserRegisterAPITest(CaptchaTest):
         response = self.client.post(self.register_url, data=self.data)
         self.assertDictEqual(response.data, {"error": "error", "data": "Email already exists"})
 
+class SessionManagementAPITest(APITestCase):
+    def setUp(self):
+        self.create_user("2020222000", "test123")
+        self.url = self.reverse("session_management_api")
+        # launch a request to provide session data
+        login_url = self.reverse("user_login_api")
+        self.client.post(login_url, data={"username": "test", "password": "test123"})
+
+    def test_get_sessions(self):
+        resp = self.client.get(self.url)
+        self.assertSuccess(resp)
+        data = resp.data["data"]
+        self.assertEqual(len(data), 1)
+
+    # def test_delete_session_key(self):
+    #     resp = self.client.delete(self.url + "?session_key=" + self.session_key)
+    #     self.assertSuccess(resp)
+
+    def test_delete_session_with_invalid_key(self):
+        resp = self.client.delete(self.url + "?session_key=aaaaaaaaaa")
+        self.assertDictEqual(resp.data, {"error": "error", "data": "Invalid session_key"})
 
 class UserProfileAPITest(APITestCase):
     def setUp(self):

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
-                        AvatarUploadAPI, UserProfileAPI, UserRankAPI, SessionManagementAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
+                        AvatarUploadAPI, UserProfileAPI, UserRankAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView
 
@@ -22,7 +22,6 @@ urlpatterns = [
     url(r"^user/?$", UserSettingAPI.as_view(), name="user_setting_api"),
     url(r"^upload_avatar/?$", AvatarUploadAPI.as_view(), name="avatar_upload_api"),
     url(r"^user_rank/?$", UserRankAPI.as_view(), name="user_rank_api"),
-    url(r"^sessions/?$", SessionManagementAPI.as_view(), name="session_management_api"),
     url(r"^open_api_appkey/?$", OpenAPIAppkeyAPI.as_view(), name="open_api_appkey_api"),
     url(r"^sso?$", SSOAPI.as_view(), name="sso_api")
 ]

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -4,7 +4,7 @@ from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
                         AvatarUploadAPI, UserProfileAPI,
-                        UserRankAPI, SessionManagementAPI,
+                        UserRankAPI, 
                         OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -3,8 +3,7 @@ from django.conf.urls import url
 from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
-                        AvatarUploadAPI, UserProfileAPI, 
-                        UserRankAPI, SessionManagementAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
+                        AvatarUploadAPI, UserProfileAPI, UserRankAPI, SessionManagementAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView
 

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -3,8 +3,8 @@ from django.conf.urls import url
 from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
-                        AvatarUploadAPI, UserProfileAPI,
-                        UserRankAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
+                        AvatarUploadAPI, UserProfileAPI, 
+                        UserRankAPI, SessionManagementAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView
 
@@ -23,6 +23,7 @@ urlpatterns = [
     url(r"^user/?$", UserSettingAPI.as_view(), name="user_setting_api"),
     url(r"^upload_avatar/?$", AvatarUploadAPI.as_view(), name="avatar_upload_api"),
     url(r"^user_rank/?$", UserRankAPI.as_view(), name="user_rank_api"),
+    url(r"^sessions/?$", SessionManagementAPI.as_view(), name="session_management_api"),
     url(r"^open_api_appkey/?$", OpenAPIAppkeyAPI.as_view(), name="open_api_appkey_api"),
     url(r"^sso?$", SSOAPI.as_view(), name="sso_api")
 ]

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -4,8 +4,7 @@ from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
                         AvatarUploadAPI, UserProfileAPI,
-                        UserRankAPI, 
-                        OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
+                        UserRankAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView
 

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
-                        AvatarUploadAPI, UserProfileAPI, UserRankAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
+                        AvatarUploadAPI, UserProfileAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView
 
@@ -21,7 +21,6 @@ urlpatterns = [
     url(r"^profile/?$", UserProfileAPI.as_view(), name="user_profile_api"),
     url(r"^user/?$", UserSettingAPI.as_view(), name="user_setting_api"),
     url(r"^upload_avatar/?$", AvatarUploadAPI.as_view(), name="avatar_upload_api"),
-    url(r"^user_rank/?$", UserRankAPI.as_view(), name="user_rank_api"),
     url(r"^open_api_appkey/?$", OpenAPIAppkeyAPI.as_view(), name="open_api_appkey_api"),
     url(r"^sso?$", SSOAPI.as_view(), name="sso_api")
 ]

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -3,9 +3,9 @@ from django.conf.urls import url
 from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
-                        AvatarUploadAPI, TwoFactorAuthAPI, UserProfileAPI,
-                        CheckTFARequiredAPI, SessionManagementAPI,
-                        ProfileProblemDisplayIDRefreshAPI, OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
+                        AvatarUploadAPI, UserProfileAPI,
+                        UserRankAPI, SessionManagementAPI,
+                        OpenAPIAppkeyAPI, SSOAPI, UserSettingAPI)
 
 from utils.captcha.views import CaptchaAPIView
 
@@ -22,11 +22,8 @@ urlpatterns = [
     url(r"^check_username_or_email", UsernameOrEmailCheck.as_view(), name="check_username_or_email"),
     url(r"^profile/?$", UserProfileAPI.as_view(), name="user_profile_api"),
     url(r"^user/?$", UserSettingAPI.as_view(), name="user_setting_api"),
-    url(r"^profile/fresh_display_id", ProfileProblemDisplayIDRefreshAPI.as_view(), name="display_id_fresh"),
     url(r"^upload_avatar/?$", AvatarUploadAPI.as_view(), name="avatar_upload_api"),
-    url(r"^tfa_required/?$", CheckTFARequiredAPI.as_view(), name="tfa_required_check"),
-    url(r"^two_factor_auth/?$", TwoFactorAuthAPI.as_view(), name="two_factor_auth_api"),
-    url(r"^sessions/?$", SessionManagementAPI.as_view(), name="session_management_api"),
+    url(r"^user_rank/?$", UserRankAPI.as_view(), name="user_rank_api"),
     url(r"^open_api_appkey/?$", OpenAPIAppkeyAPI.as_view(), name="open_api_appkey_api"),
     url(r"^sso?$", SSOAPI.as_view(), name="sso_api")
 ]

--- a/backend/account/views/oj.py
+++ b/backend/account/views/oj.py
@@ -25,8 +25,8 @@ from ..models import User, UserProfile
 from ..serializers import (ApplyResetPasswordSerializer, ResetPasswordSerializer,
                            UserChangePasswordSerializer, UserLoginSerializer,
                            UserRegisterSerializer, EmailAuthSerializer, UsernameOrEmailCheckSerializer,
-                           UserChangeEmailSerializer, SSOSerializer)
-from ..serializers import (TwoFactorAuthCodeSerializer, UserProfileSerializer,
+                           RankInfoSerializer, UserChangeEmailSerializer, SSOSerializer)
+from ..serializers import (UserProfileSerializer,
                            EditUserProfileSerializer, ImageUploadForm, EditUserSettingSerializer, UserSerializer)
 from ..tasks import send_email_async
 
@@ -146,83 +146,6 @@ class AvatarUploadAPI(APIView):
         user_profile.avatar = f"{settings.AVATAR_URI_PREFIX}/{name}"
         user_profile.save()
         return self.success("Succeeded")
-
-
-class TwoFactorAuthAPI(APIView):
-    @swagger_auto_schema(operation_description="Get QR code")
-    @login_required
-    def get(self, request):
-        """
-        Get QR code
-        """
-        user = request.user
-        if user.two_factor_auth:
-            return self.error("2FA is already turned on")
-        token = rand_str()
-        user.tfa_token = token
-        user.save()
-
-        label = f"{SysOptions.website_name_shortcut}:{user.username}"
-        image = qrcode.make(OtpAuth(token).to_uri("totp", label, SysOptions.website_name.replace(" ", "")))
-        return self.success(img2base64(image))
-
-    @swagger_auto_schema(
-        request_body=TwoFactorAuthCodeSerializer,
-        operation_description="Open 2FA",
-    )
-    @login_required
-    @validate_serializer(TwoFactorAuthCodeSerializer)
-    def post(self, request):
-        """
-        Open 2FA
-        """
-        code = request.data["code"]
-        user = request.user
-        if OtpAuth(user.tfa_token).valid_totp(code):
-            user.two_factor_auth = True
-            user.save()
-            return self.success("Succeeded")
-        else:
-            return self.error("Invalid code")
-
-    @swagger_auto_schema(
-        request_body=TwoFactorAuthCodeSerializer,
-        operation_description="Turn off 2FA",
-    )
-    @login_required
-    @validate_serializer(TwoFactorAuthCodeSerializer)
-    def put(self, request):
-        code = request.data["code"]
-        user = request.user
-        if not user.two_factor_auth:
-            return self.error("2FA is already turned off")
-        if OtpAuth(user.tfa_token).valid_totp(code):
-            user.two_factor_auth = False
-            user.save()
-            return self.success("Succeeded")
-        else:
-            return self.error("Invalid code")
-
-
-class CheckTFARequiredAPI(APIView):
-    @swagger_auto_schema(
-        request_body=UsernameOrEmailCheckSerializer,
-        operation_description="Check TFA is required",
-    )
-    @validate_serializer(UsernameOrEmailCheckSerializer)
-    def post(self, request):
-        """
-        Check TFA is required
-        """
-        data = request.data
-        result = False
-        if data.get("username"):
-            try:
-                user = User.objects.get(username=data["username"])
-                result = user.two_factor_auth
-            except User.DoesNotExist:
-                pass
-        return self.success({"result": result})
 
 
 class UserLoginAPI(APIView):
@@ -469,59 +392,6 @@ class ResetPasswordAPI(APIView):
         user.set_password(data["password"])
         user.save()
         return self.success("Succeeded")
-
-
-class SessionManagementAPI(APIView):
-    @swagger_auto_schema(operation_description="Manage Session")
-    @login_required
-    def get(self, request):
-        engine = import_module(settings.SESSION_ENGINE)
-        session_store = engine.SessionStore
-        current_session = request.session.session_key
-        session_keys = request.user.session_keys
-        result = []
-        modified = False
-        for key in session_keys[:]:
-            session = session_store(key)
-            # session does not exist or is expiry
-            if not session._session:
-                session_keys.remove(key)
-                modified = True
-                continue
-
-            s = {}
-            if current_session == key:
-                s["current_session"] = True
-            s["ip"] = session["ip"]
-            s["user_agent"] = session["user_agent"]
-            s["last_activity"] = datetime2str(session["last_activity"])
-            s["session_key"] = key
-            result.append(s)
-        if modified:
-            request.user.save()
-        return self.success(result)
-
-
-class ProfileProblemDisplayIDRefreshAPI(APIView):
-    @swagger_auto_schema(
-        operation_description="Update Solved Problem List"
-    )
-    @login_required
-    def get(self, request):
-        profile = request.user.userprofile
-        acm_problems = profile.acm_problems_status.get("problems", {})
-        oi_problems = profile.oi_problems_status.get("problems", {})
-        ids = list(acm_problems.keys()) + list(oi_problems.keys())
-        if not ids:
-            return self.success()
-        display_ids = Problem.objects.filter(id__in=ids, visible=True).values_list("_id", flat=True)
-        id_map = dict(zip(ids, display_ids))
-        for k, v in acm_problems.items():
-            v["_id"] = id_map[k]
-        for k, v in oi_problems.items():
-            v["_id"] = id_map[k]
-        profile.save(update_fields=["acm_problems_status", "oi_problems_status"])
-        return self.success()
 
 
 class OpenAPIAppkeyAPI(APIView):

--- a/backend/account/views/oj.py
+++ b/backend/account/views/oj.py
@@ -394,6 +394,62 @@ class ResetPasswordAPI(APIView):
         return self.success("Succeeded")
 
 
+class SessionManagementAPI(APIView):
+    @swagger_auto_schema(operation_description="Manage Session")
+    @login_required
+    def get(self, request):
+        engine = import_module(settings.SESSION_ENGINE)
+        session_store = engine.SessionStore
+        current_session = request.session.session_key
+        session_keys = request.user.session_keys
+        result = []
+        modified = False
+        for key in session_keys[:]:
+            session = session_store(key)
+            # session does not exist or is expiry
+            if not session._session:
+                session_keys.remove(key)
+                modified = True
+                continue
+
+            s = {}
+            if current_session == key:
+                s["current_session"] = True
+            s["ip"] = session["ip"]
+            s["user_agent"] = session["user_agent"]
+            s["last_activity"] = datetime2str(session["last_activity"])
+            s["session_key"] = key
+            result.append(s)
+        if modified:
+            request.user.save()
+        return self.success(result)
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                name="session_key",
+                in_=openapi.IN_QUERY,
+                description="Session Key",
+                type=openapi.TYPE_STRING,
+                required=True,
+            ),
+        ],
+        operation_description="Delete session key"
+    )
+    @login_required
+    def delete(self, request):
+        session_key = request.GET.get("session_key")
+        if not session_key:
+            return self.error("Parameter Error")
+        request.session.delete(session_key)
+        if session_key in request.user.session_keys:
+            request.user.session_keys.remove(session_key)
+            request.user.save()
+            return self.success("Succeeded")
+        else:
+            return self.error("Invalid session_key")
+
+
 class OpenAPIAppkeyAPI(APIView):
     @swagger_auto_schema(
         operation_description="Configure whether user can use open_api. If possible, generate APIAppkey.",

--- a/backend/account/views/oj.py
+++ b/backend/account/views/oj.py
@@ -3,7 +3,6 @@ import re
 from datetime import timedelta
 from importlib import import_module
 
-import qrcode
 from django.conf import settings
 from django.contrib import auth
 from django.template.loader import render_to_string
@@ -15,11 +14,11 @@ from drf_yasg import openapi
 from otpauth import OtpAuth
 from rest_framework.parsers import MultiPartParser
 
-from problem.models import Problem
+from utils.constants import ContestRuleType
 from options.options import SysOptions
 from utils.api import APIView, validate_serializer, CSRFExemptAPIView
 from utils.captcha import Captcha
-from utils.shortcuts import rand_str, img2base64, datetime2str
+from utils.shortcuts import rand_str, datetime2str
 from ..decorators import login_required
 from ..models import User, UserProfile
 from ..serializers import (ApplyResetPasswordSerializer, ResetPasswordSerializer,

--- a/backend/account/views/oj.py
+++ b/backend/account/views/oj.py
@@ -1,7 +1,6 @@
 import os
 import re
 from datetime import timedelta
-from importlib import import_module
 
 from django.conf import settings
 from django.contrib import auth
@@ -18,7 +17,7 @@ from utils.constants import ContestRuleType
 from options.options import SysOptions
 from utils.api import APIView, validate_serializer, CSRFExemptAPIView
 from utils.captcha import Captcha
-from utils.shortcuts import rand_str, datetime2str
+from utils.shortcuts import rand_str
 from ..decorators import login_required
 from ..models import User, UserProfile
 from ..serializers import (ApplyResetPasswordSerializer, ResetPasswordSerializer,

--- a/backend/account/views/oj.py
+++ b/backend/account/views/oj.py
@@ -13,7 +13,6 @@ from drf_yasg import openapi
 from otpauth import OtpAuth
 from rest_framework.parsers import MultiPartParser
 
-from utils.constants import ContestRuleType
 from options.options import SysOptions
 from utils.api import APIView, validate_serializer, CSRFExemptAPIView
 from utils.captcha import Captcha
@@ -23,7 +22,7 @@ from ..models import User, UserProfile
 from ..serializers import (ApplyResetPasswordSerializer, ResetPasswordSerializer,
                            UserChangePasswordSerializer, UserLoginSerializer,
                            UserRegisterSerializer, EmailAuthSerializer, UsernameOrEmailCheckSerializer,
-                           RankInfoSerializer, UserChangeEmailSerializer, SSOSerializer)
+                           UserChangeEmailSerializer, SSOSerializer)
 from ..serializers import (UserProfileSerializer,
                            EditUserProfileSerializer, ImageUploadForm, EditUserSettingSerializer, UserSerializer)
 from ..tasks import send_email_async

--- a/backend/account/views/oj.py
+++ b/backend/account/views/oj.py
@@ -393,62 +393,6 @@ class ResetPasswordAPI(APIView):
         return self.success("Succeeded")
 
 
-class SessionManagementAPI(APIView):
-    @swagger_auto_schema(operation_description="Manage Session")
-    @login_required
-    def get(self, request):
-        engine = import_module(settings.SESSION_ENGINE)
-        session_store = engine.SessionStore
-        current_session = request.session.session_key
-        session_keys = request.user.session_keys
-        result = []
-        modified = False
-        for key in session_keys[:]:
-            session = session_store(key)
-            # session does not exist or is expiry
-            if not session._session:
-                session_keys.remove(key)
-                modified = True
-                continue
-
-            s = {}
-            if current_session == key:
-                s["current_session"] = True
-            s["ip"] = session["ip"]
-            s["user_agent"] = session["user_agent"]
-            s["last_activity"] = datetime2str(session["last_activity"])
-            s["session_key"] = key
-            result.append(s)
-        if modified:
-            request.user.save()
-        return self.success(result)
-
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
-                name="session_key",
-                in_=openapi.IN_QUERY,
-                description="Session Key",
-                type=openapi.TYPE_STRING,
-                required=True,
-            ),
-        ],
-        operation_description="Delete session key"
-    )
-    @login_required
-    def delete(self, request):
-        session_key = request.GET.get("session_key")
-        if not session_key:
-            return self.error("Parameter Error")
-        request.session.delete(session_key)
-        if session_key in request.user.session_keys:
-            request.user.session_keys.remove(session_key)
-            request.user.save()
-            return self.success("Succeeded")
-        else:
-            return self.error("Invalid session_key")
-
-
 class OpenAPIAppkeyAPI(APIView):
     @swagger_auto_schema(
         operation_description="Configure whether user can use open_api. If possible, generate APIAppkey.",


### PR DESCRIPTION
checkUsernameOrEmail 
-         (살려두기로 함)


freshDisplayID (userID) - UserHome.vue - Deleted | 'api/profile/fresh_display_id', 'get'  
- 	account>urls>oj.py - profile/fresh_display_id url 삭제
- 	account>views>oj.py - ProfileProblemDisplayIDRefreshAPI 클래스 삭제


twoFactorAuth (method, data) - No use - Deleted | 'api/two_factor_auth', -
- 	account>urls>oj.py - two_factor_auth url 삭제
- 	account>views>oj.py - TwoFactorAuthAPI 클래스 삭제
- 	account>serializers.py - TwoFactorAuthCodeSerializer 클래스 삭제
- 	account>tests.py - TwoFactorAuthAPITest 클래스 삭제


tfaRequiredCheck (username) - No use - Deleted | 'api/tfa_required', 'post'
- 	account>urls>oj.py - tfa_required url 삭제
- 	account>views>oj.py - CheckTFARequiredAPI 클래스 삭제
- 	account>tests.py - TFARequiredCheckAPITest 클래스 삭제


getSessions () - No use (Admin에서는 사용됨) - Deleted | 'api/sessions', 'get'
- 	account>urls>oj.py - sessions url 삭제
- 	account>views>oj.py - SessionManagementAPI 클래스 삭제(get, delete 메소드 둘 다 사용되지 않음)
- 	account>tess.py - SessionManagementAPITest 클래스 삭제