### PR TITLE
admin user page 수정

### DIFF
--- a/frontend/src/i18n/admin/en-US.js
+++ b/frontend/src/i18n/admin/en-US.js
@@ -28,6 +28,7 @@ export const m = {
   User_Email: 'Email',
   User_New_Password: 'New Password',
   User_Type: 'User Type',
+  User_Major: 'User Major',
   Problem_Permission: 'Problem Permission',
   Two_Factor_Auth: 'Two Factor Auth',
   Is_Disabled: 'Is Disabled',

--- a/frontend/src/pages/admin/views/general/User.vue
+++ b/frontend/src/pages/admin/views/general/User.vue
@@ -83,9 +83,18 @@
         </el-table-column>
 
         <el-table-column
+          prop="major"
+          label="User Major"
+        >
+          <template slot-scope="scope">
+            {{ scope.row.major }}
+          </template>
+        </el-table-column>
+
+        <el-table-column
           fixed="right"
           label="Option"
-          width="200"
+          width="120"
         >
           <template slot-scope="{row}">
             <icon-btn
@@ -290,7 +299,7 @@
     >
       <el-form
         :model="user"
-        label-width="120px"
+        label-width="140px"
         label-position="left"
       >
         <el-row :gutter="20">
@@ -305,7 +314,6 @@
           <el-col :span="12">
             <el-form-item
               :label="$t('m.User_Real_Name')"
-              required
             >
               <el-input v-model="user.real_name" />
             </el-form-item>
@@ -342,6 +350,24 @@
             </el-form-item>
           </el-col>
           <el-col :span="12">
+            <el-form-item :label="$t('m.User_Major')">
+              <el-select v-model="user.major">
+                <el-option
+                  label="Major(원전공)"
+                  value="Major"
+                />
+                <el-option
+                  label="Double Major(복수전공)"
+                  value="Double Major"
+                />
+                <el-option
+                  label="Non-CS Major(비전공)"
+                  value="Non-CS Major"
+                />
+              </el-select>
+            </el-form-item>
+          </el-col>
+          <el-col :span="20">
             <el-form-item :label="$t('m.Problem_Permission')">
               <el-select
                 v-model="user.problem_permission"
@@ -478,7 +504,6 @@ export default {
       this.showUserDialog = true
       api.getUser(id).then(res => {
         this.user = res.data.data
-        this.user.password = ''
         this.user.real_tfa = this.user.two_factor_auth
       })
     },


### PR DESCRIPTION
[ admin user page의 user 부분 ]
- major field 추가 (이에 따른 option 너비 변경)

[ admin user edit dialog ]
- user major field 추가
- admin label 너비 변경 ( problem permission이 잘려서 잘리지 않도록 수정했습니다 )
- password를 변경할 수 있도록 수정
- real name이 필수가 아니라서 required 삭제

![image](https://user-images.githubusercontent.com/75013515/123638000-9cd7a800-d859-11eb-9ec9-5158e0401e02.png)
![image](https://user-images.githubusercontent.com/75013515/123637606-2fc41280-d859-11eb-9e4e-a7df78c722b9.png)
