### PR TITLE
Apply PgBouncer for DB Connection Pooling

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -45,7 +45,9 @@ jobs:
 
       - name: Create Demo Database
         working-directory: ${{ env.working-directory }}
-        run: ./init_db.sh
+        run: |
+          ./init_db.sh
+          python manage.py migrate
 
       - name: Docker Containers List
         run: docker ps -a
@@ -56,7 +58,7 @@ jobs:
 
       - name: Django Test
         working-directory: ${{ env.working-directory }}
-        run: python3 -m coverage run --include="$PWD/*" manage.py test
+        run: python3 -m coverage run --include="$PWD/*" manage.py test --testrunner=oj.test_runner.TestRunner
       
       - name: Result of Django Test
         working-directory: ${{ env.working-directory }}

--- a/backend/init_db.sh
+++ b/backend/init_db.sh
@@ -7,9 +7,15 @@ if [[ ! -f manage.py ]]; then
 fi
 
 sleep 2
-docker rm -f oj-postgres-dev oj-redis-dev
-docker run -it -d -e POSTGRES_DB=onlinejudge -e POSTGRES_USER=onlinejudge -e POSTGRES_PASSWORD=onlinejudge -p 127.0.0.1:5435:5432 --name oj-postgres-dev postgres:10
+docker rm -f oj-postgres-dev oj-redis-dev pgbouncer-dev
+docker network rm skku-coding-platform-dev
+
+docker network create skku-coding-platform-dev
+docker run -it -d -e POSTGRES_DB=onlinejudge -e POSTGRES_USER=onlinejudge -e POSTGRES_PASSWORD=onlinejudge --network skku-coding-platform-dev -p 127.0.0.1:5435:5432 --name oj-postgres-dev postgres:10
 docker run -it -d -p 127.0.0.1:6380:6379 --name oj-redis-dev redis:4.0-alpine
+docker run -it -d -e DB_USER=onlinejudge -e DB_PASSWORD=onlinejudge -e DB_HOST=oj-postgres-dev -e DB_NAME=onlinejudge \
+-e ADMIN_USERS=onlinejudge -e DB_PORT=5432 -e LISTEN_PORT=6543 -e POOL_MODE=transaction \
+-e SERVER_CHECK_DELAY=3000 -e MAX_CLIENT_CONN=3000 -e MIN_POOL_SIZE=100 -e DEFAULT_POOL_SIZE=100 --network skku-coding-platform-dev -p 127.0.0.1:6542:6543 --name pgbouncer-dev edoburu/pgbouncer
 
 if [ "$1" = "--migrate" ]; then
     sleep 3

--- a/backend/oj/dev_settings.py
+++ b/backend/oj/dev_settings.py
@@ -6,8 +6,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'HOST': '127.0.0.1',
-        'PORT': 5435,
+        'HOST': "pgbouncer",
+        'PORT': 6543,
         'NAME': "onlinejudge",
         'USER': "onlinejudge",
         'PASSWORD': 'onlinejudge'

--- a/backend/oj/dev_settings.py
+++ b/backend/oj/dev_settings.py
@@ -6,8 +6,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'HOST': "pgbouncer",
-        'PORT': 6543,
+        'HOST': '127.0.0.1',
+        'PORT': '6542',
         'NAME': "onlinejudge",
         'USER': "onlinejudge",
         'PASSWORD': 'onlinejudge'

--- a/backend/oj/production_settings.py
+++ b/backend/oj/production_settings.py
@@ -3,8 +3,8 @@ from utils.shortcuts import get_env
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'HOST': get_env("POSTGRES_HOST", "oj-postgres"),
-        'PORT': get_env("POSTGRES_PORT", "5432"),
+        'HOST': "pgbouncer",
+        'PORT': "6543",
         'NAME': get_env("POSTGRES_DB"),
         'USER': get_env("POSTGRES_USER"),
         'PASSWORD': get_env("POSTGRES_PASSWORD")

--- a/backend/oj/test_runner.py
+++ b/backend/oj/test_runner.py
@@ -1,0 +1,9 @@
+from django.test.runner import DiscoverRunner
+
+
+class TestRunner(DiscoverRunner):
+    def setup_databases(self, **kwargs):
+        pass
+
+    def teardown_databases(self, old_config, **kwargs):
+        pass

--- a/backend/options/options.py
+++ b/backend/options/options.py
@@ -117,7 +117,7 @@ class OptionDefaultValue:
     smtp_config = {}
     judge_server_token = default_token
     throttling = {"ip": {"capacity": 100, "fill_rate": 0.1, "default_capacity": 50},
-                  "user": {"capacity": 20, "fill_rate": 0.03, "default_capacity": 10}}
+                  "user": {"capacity": 20, "fill_rate": 0.2, "default_capacity": 10}}
     languages = languages
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,3 +62,22 @@ services:
     ports:
       - "0.0.0.0:80:8000"
       - "0.0.0.0:443:1443"
+
+  pgbouncer:
+    image: edoburu/pgbouncer
+    container_name: pgbouncer
+    depends_on:
+      - oj-postgres
+    environment:
+      - DB_USER=onlinejudge
+      - DB_PASSWORD=onlinejudge
+      - DB_HOST=oj-postgres
+      - DB_NAME=onlinejudge
+      - ADMIN_USERS=onlinejudge
+      - DB_PORT=5432
+      - LISTEN_PORT=6543 
+      - POOL_MODE=transaction
+      - SERVER_CHECK_DELAY=3000 
+      - MAX_CLIENT_CONN=3000 
+      - MIN_POOL_SIZE=100
+      - DEFAULT_POOL_SIZE=100


### PR DESCRIPTION
db connection pooling을 위해 pgbouncer 적용 및 throttling의 파라미터 수정.
load test 결과 500명이 서버에 상주하면서 제출을 계속 시도해도 안전하게 db와 연결됨(500명 이상도 이론적으로는 가능).
각 파라미터에 대한 설명은 wiki에 추가할 예정.