### PR TITLE
postgresql deadlock issue 관련 수정

### DIFF
--- a/backend/judge/dispatcher.py
+++ b/backend/judge/dispatcher.py
@@ -37,8 +37,9 @@ class ChooseJudgeServer:
 
     def __enter__(self) -> [JudgeServer, None]:
         with transaction.atomic():
-            servers = JudgeServer.objects.select_for_update().filter(is_disabled=False).order_by("task_number")
+            servers = JudgeServer.objects.select_for_update().filter(is_disabled=False).order_by("id")
             servers = [s for s in servers if s.status == "normal"]
+            servers.sort(key=lambda server: server.task_number)
             for server in servers:
                 if server.task_number <= server.cpu_core * 2:
                     server.task_number = F("task_number") + 1


### PR DESCRIPTION
데드락 이슈는 대량의 submission이 발생할 때, 아래 코드에 의해서 발생합니다. 

```jsx
servers = JudgeServer.objects.select_for_update().filter(is_disabled=False).order_by("task_number")
```

select for update 쿼리의 데드락을 피하는 방법은 select된 row들을 order_by로 특정 순서로 정렬한 후에 lockrows을 걸도록 하는 것입니다. 하지만 기존의 정렬 기준인 task_number는 unique하지 않고, 상황에 따라 값이 바뀔 수 있어서 데드락을 회피하기에는 적절하지 않은 정렬 기준이라고 생각했습니다. 따라서 primary key인 id를 정렬 기준으로 사용해서 postgresql에서 데드락을 피하도록 하고, 값을 받아온 이후 task_number로 재정렬하도록 수정했습니다.

간단하게 테스트해봤을 때 데드락이 발생하지는 않았지만, 데드락 오류 자체가 매우 레어하게 발생하기 때문에 해결된 것인지 우연히 발생하지 않은 것인지 판별이 어렵습니다.

Close #125