### PR TITLE
Edit admin page container width to be full

### DIFF
--- a/frontend/src/pages/admin/components/SideMenu.vue
+++ b/frontend/src/pages/admin/components/SideMenu.vue
@@ -127,7 +127,7 @@ export default {
 <style scoped lang="less">
   .vertical_menu {
     overflow: auto;
-    width: 205px;
+    width: 200px;
     height: 100%;
     position: fixed !important;
     z-index: 100;

--- a/frontend/src/pages/admin/views/Home.vue
+++ b/frontend/src/pages/admin/views/Home.vue
@@ -154,7 +154,7 @@ export default {
 
   .content-app {
     padding-top: 20px;
-    padding-right: 10px;
+    padding-right: 20px;
     padding-left: 210px;
   }
 

--- a/frontend/src/pages/admin/views/Home.vue
+++ b/frontend/src/pages/admin/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div id="container">
     <div>
       <SideMenu />
     </div>
@@ -126,7 +126,7 @@ export default {
     border-style: none
   }
 
-  .container {
+  #container {
     overflow: auto;
     font-weight: 400;
     height: 100%;
@@ -155,7 +155,7 @@ export default {
   .content-app {
     padding-top: 20px;
     padding-right: 10px;
-    padding-left: 10px;
+    padding-left: 210px;
   }
 
   .footer {


### PR DESCRIPTION
`container` class가 Bootstrap CSS와 충돌 문제로 width, padding 속성이 제대로 적용되지 않는 문제가 있었다.
class 대신 id를 사용하여 충돌을 막았다.

### Before
![before](https://user-images.githubusercontent.com/19747913/125180348-e64dcd00-e233-11eb-887a-db93e47bd61a.PNG)


### After
![after](https://user-images.githubusercontent.com/19747913/125180355-1301e480-e234-11eb-9c89-c32f4e601cc6.PNG)
