### PR TITLE
(minor) Add quotes to `v-dompurify-html` props

### DIFF
--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -134,12 +134,12 @@
       <b-col id="problem-description" cols="5">
         <div class="description-io" v-katex>
           <h2>Description</h2>
-          <p v-dompurify-html=problem.description></p>
+          <p v-dompurify-html="problem.description"></p>
           <div class="blank-line"></div>
           <h2>Input</h2>
-          <p v-dompurify-html=problem.input_description></p>
+          <p v-dompurify-html="problem.input_description"></p>
           <h2>Output</h2>
-          <p v-dompurify-html=problem.output_description></p>
+          <p v-dompurify-html="problem.output_description"></p>
           <div class="blank-line"></div>
         </div>
 
@@ -163,7 +163,7 @@
 
         <div v-if="problem.hint" v-katex>
           <h2>Hint</h2>
-          <p v-dompurify-html=problem.hint></p>
+          <p v-dompurify-html="problem.hint"></p>
         </div>
       </b-col>
       <b-col id="console" cols="7">


### PR DESCRIPTION
스타일 통일 및 GitHub highlight 해결

### Before
![image](https://user-images.githubusercontent.com/19747913/126773320-71759809-86ac-48d4-945b-a3ded415ee75.png)
![image](https://user-images.githubusercontent.com/19747913/126773223-179670d0-2ceb-45bf-9ea0-29ed2a2da166.png)

### After
![image](https://user-images.githubusercontent.com/19747913/126773387-e140c2c0-fa11-4b3f-b7f7-d933624e9201.png)
![image](https://user-images.githubusercontent.com/19747913/126773250-24a306f1-a1ed-4af0-b5ba-222610592fa5.png)
