### PR TITLE
Show Submission Detail when compile error occurs

### DIFF
--- a/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
+++ b/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
@@ -140,6 +140,9 @@
             </template>
           </b-table>
         </div>
+        <div id="submission-compile-error-message" v-if="compile_error_message_show">
+          <p class="text-danger"> Compile error message: {{ submission_detail.statistic_info.err_info }} </p>
+        </div>
         <div id="submission-source-code">
           <h3>Source Code</h3>
           <p>({{submission_detail.bytes}} Bytes)</p>
@@ -225,6 +228,7 @@ export default {
       all_submissions_page: 1,
 
       submission_detail_modal_show: false,
+      compile_error_message_show: false,
 
       // for re-rendering when codemirror content is ready
       codemirror_key: 1
@@ -335,7 +339,7 @@ export default {
         create_time: time.utcToLocal(data.create_time, 'YYYY-MM-DD HH:mm'),
         result: JUDGE_STATUS[data.result].name,
         bytes: new Blob([data.code]).size,
-        testcases: data.info.data.map(
+        testcases: data.info.data && data.info.data.map(
           tc => {
             return {
               title: tc.test_case,
@@ -346,6 +350,7 @@ export default {
           }
         )
       }
+      this.compile_error_message_show = data.result === 'Compile Error'
 
       if (data.info && data.info.data) {
         // score exist means the submission is OI problem submission
@@ -506,6 +511,10 @@ export default {
             tr td:last-child {
               padding-right: 50px;
             }
+          }
+
+          #submission-compile-error-message {
+            padding: 20px 50px;
           }
 
           #submission-source-code {


### PR DESCRIPTION
Submit했을 때 Compile Error가 발생하면 Submission Detail을 확인할 수 없는 문제해결
(Accepted, Wrong answer, Runtime error 등의 경우에는 잘 동작함)

Compile Error 시 map 메소드를 실행하지 않도록 data.info.data가 있는지 확인하는 절차 추가

Compile Error의 경우에는 추가로 컴파일 에러 메시지를 보여주기 위해서 기존 api response를 활용하여 submission_detail.statistic_info.err_inf를 활용함. 

++ 사이드바를 통해 Submission Detail modal을 띄울 경우 제출한 소스 코드가 잘 보이는데 Reset 버튼 왼쪽의 제출 결과 를 눌러 modal을 띄우면 소스 코드가 깨져서 보임

Close #187 

After: 
![image](https://user-images.githubusercontent.com/73051219/127034239-1b4ae1da-6fd3-45bf-b20c-6f0b2ee6526a.png)

++ 소스 코드 깨지는 문제 Screenshot
![image](https://user-images.githubusercontent.com/73051219/127034347-265d85d3-0478-4067-a43f-65cf8f3e4e9c.png)
