### PR TITLE
이메일 인증 전 이메일 변경 기능 추가

### DIFF
--- a/backend/account/serializers.py
+++ b/backend/account/serializers.py
@@ -37,6 +37,12 @@ class UserChangeEmailSerializer(serializers.Serializer):
     new_email = serializers.EmailField(max_length=64)
 
 
+class UserChangeEmailForAuthSerializer(serializers.Serializer):
+    username = serializers.CharField(max_length=32)
+    password = serializers.CharField()
+    email = serializers.EmailField(max_length=64)
+
+
 class GenerateUserSerializer(serializers.Serializer):
     prefix = serializers.CharField(max_length=16, allow_blank=True)
     suffix = serializers.CharField(max_length=16, allow_blank=True)

--- a/backend/account/urls/oj.py
+++ b/backend/account/urls/oj.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI,
+from ..views.oj import (ApplyResetPasswordAPI, ResetPasswordAPI, UserChangeEmailForAuthAPI,
                         UserChangePasswordAPI, UserRegisterAPI, EmailAuthAPI, UserChangeEmailAPI,
                         UserLoginAPI, UserLogoutAPI, UsernameOrEmailCheck,
                         AvatarUploadAPI, UserProfileAPI, UserSettingAPI)
@@ -14,6 +14,7 @@ urlpatterns = [
     url(r"^email_auth/?$", EmailAuthAPI.as_view(), name="email_auth_api"),
     url(r"^change_password/?$", UserChangePasswordAPI.as_view(), name="user_change_password_api"),
     url(r"^change_email/?$", UserChangeEmailAPI.as_view(), name="user_change_email_api"),
+    url(r"^change_email_for_auth/?$", UserChangeEmailForAuthAPI.as_view(), name="change_email_for_auth_api"),
     url(r"^apply_reset_password/?$", ApplyResetPasswordAPI.as_view(), name="apply_reset_password_api"),
     url(r"^reset_password/?$", ResetPasswordAPI.as_view(), name="reset_password_api"),
     url(r"^captcha/?$", CaptchaAPIView.as_view(), name="show_captcha"),

--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -105,6 +105,11 @@ export default {
       data
     })
   },
+  changeEmailForAuth (data) {
+    return ajax('change_email_for_auth', 'post', {
+      data
+    })
+  },
   getLanguages () {
     return ajax('languages', 'get')
   },

--- a/frontend/src/pages/oj/components/Header.vue
+++ b/frontend/src/pages/oj/components/Header.vue
@@ -57,13 +57,15 @@ import register from '@oj/views/user/Register'
 import login from '@oj/views/user/Login'
 import profileSetting from '@oj/views/user/ProfileSetting'
 import ApplyResetPassword from '@oj/views/user/ApplyResetPassword'
+import ChangeEmailForAuth from '@oj/views/user/ChangeEmailForAuth'
 
 export default {
   components: {
     login,
     register,
     profileSetting,
-    ApplyResetPassword
+    ApplyResetPassword,
+    ChangeEmailForAuth
   },
   mounted () {
     this.getProfile()

--- a/frontend/src/pages/oj/views/user/ChangeEmailForAuth.vue
+++ b/frontend/src/pages/oj/views/user/ChangeEmailForAuth.vue
@@ -1,0 +1,74 @@
+<template>
+    <div class="font-bold">
+        <div class="logo-title font-bold">
+            <h4>Change Email</h4>
+        </div>
+        <b-form ref="formChangeEmail" :model="formChangeEmail">
+            <b-container fluid="xl">
+                <b-row class="mb-4">
+                    <b-form-input v-model="formChangeEmail.username" placeholder="Student ID"/>
+                </b-row>
+                <b-row class="mb-4">
+                    <b-form-input type="password" v-model="formChangeEmail.password" placeholder="Password"/>
+                </b-row>
+                <b-row class="mb-4">
+                    <b-form-input type="email" v-model="formChangeEmail.email" placeholder="New Email Address"/>
+                </b-row>
+                <b-button @click="changeEmail" variant="success" class="delete-btn mb-4">
+                    <b-spinner v-if="btnLoading" small></b-spinner> Change Email And Request Auth
+                </b-button>
+            </b-container>
+        </b-form>
+    </div>
+</template>
+
+<script>
+import api from '@oj/api'
+import { mapActions } from 'vuex'
+export default {
+  data () {
+    return {
+      btnLoading: false,
+      formChangeEmail: {
+        username: '',
+        password: '',
+        email: ''
+      }
+    }
+  },
+  methods: {
+    ...mapActions(['changeModalStatus']),
+    async changeEmail () {
+      const formData = Object.assign({}, this.formChangeEmail)
+      this.btnLoading = true
+      try {
+        await api.changeEmailForAuth(formData)
+        this.$success('Please check your mailbox.', 2500)
+        this.changeModalStatus({ visible: false })
+        this.btnLoading = false
+      } catch (err) {
+        this.btnLoading = false
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+    @font-face {
+        font-family: Manrope_bold;
+        src: url('../../../../fonts/Manrope-Bold.ttf');
+    }
+    .logo-title {
+        margin:8px 0 28px 0;
+        color: #8DC63F;
+        text-align:center;
+    }
+    .font-bold {
+        font-family: manrope_bold;
+    }
+    .delete-btn {
+        width:284px;
+        margin-left:18px;
+    }
+</style>

--- a/frontend/src/pages/oj/views/user/Login.vue
+++ b/frontend/src/pages/oj/views/user/Login.vue
@@ -24,6 +24,7 @@
       </b-form>
       <div class="modal-low mt-5 font-bold">
         <a v-if="website.allow_register" @click.stop="handleBtnClick('register')" style="float:left;">Register now</a>
+        <a @click.stop="handleBtnClick('ChangeEmailForAuth')" style="margin-left: 30px;">Change Email</a>
         <a @click.stop="handleBtnClick('ApplyResetPassword')" style="float: right;">Forgot Password</a>
       </div>
   </div>


### PR DESCRIPTION
register할때 이메일을 잘못입력하는 경우가 종종 있어, 이메일 인증 전 이메일 변경 기능을 추가했습니다.
login 모달 창에 이메일 변경 기능을 추가했습니다.
프론트엔드 -> login 모달창 버튼 추가, 이메일 변경 모달창 생성
백엔드 -> 이메일 변경 API 추가