### PR TITLE
Add HSTS, CSP headers

### DIFF
--- a/backend/conf/views.py
+++ b/backend/conf/views.py
@@ -24,7 +24,7 @@ from problem.models import Problem
 from submission.models import Submission
 from utils.api import APIView, CSRFExemptAPIView, validate_serializer
 from utils.decorators import super_admin_required
-from utils.shortcuts import send_email, get_env
+from utils.shortcuts import send_email
 from utils.xss_filter import XSSHtml
 from .models import JudgeServer
 from .serializers import (CreateEditWebsiteConfigSerializer,
@@ -287,8 +287,5 @@ class DashboardInfoAPI(APIView):
             "user_count": User.objects.count(),
             "recent_contest_count": recent_contest_count,
             "today_submission_count": today_submission_count,
-            "judge_server_count": judge_server_count,
-            "env": {
-                "FORCE_HTTPS": get_env("FORCE_HTTPS", default=False),
-            }
+            "judge_server_count": judge_server_count
         })

--- a/backend/deploy/entrypoint.sh
+++ b/backend/deploy/entrypoint.sh
@@ -23,14 +23,6 @@ if [ ! -f "$SSL/server.key" ]; then
         -subj "/C=CN/ST=Beijing/L=Beijing/O=Beijing OnlineJudge Technology Co., Ltd./OU=Service Infrastructure Department/CN=`hostname`" -nodes
 fi
 
-cd $APP/deploy/nginx
-ln -sf locations.conf https_locations.conf
-if [ -z "$FORCE_HTTPS" ]; then
-    ln -sf locations.conf http_locations.conf
-else
-    ln -sf https_redirect.conf http_locations.conf
-fi
-
 if [ ! -z "$LOWER_IP_HEADER" ]; then
     sed -i "s/__IP_HEADER__/\$http_$LOWER_IP_HEADER/g" api_proxy.conf;
 else

--- a/backend/deploy/nginx/https_redirect.conf
+++ b/backend/deploy/nginx/https_redirect.conf
@@ -1,7 +1,0 @@
-location /api/judge_server_heartbeat {
-    include api_proxy.conf;
-}
-
-location / {
-    return 301 https://$host$request_uri;
-}

--- a/backend/deploy/nginx/locations.conf
+++ b/backend/deploy/nginx/locations.conf
@@ -11,6 +11,11 @@ location /admin {
     try_files $uri $uri/ /index.html =404;
 }
 
+location /prof {
+    root /app/dist/prof;
+    try_files $uri $uri/ /index.html =404;
+}
+
 location /.well-known {
     alias /data/ssl/.well-known;
 }

--- a/backend/deploy/nginx/nginx.conf
+++ b/backend/deploy/nginx/nginx.conf
@@ -35,12 +35,20 @@ http {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-Content-Type-Options nosniff always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-v5PbjwjOs+BSUS56dMOiJKfP+FAFRmoHxxhyakuYMtA='; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data: *.w3.org; font-src 'self' fonts.gstatic.com data:;" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     server {
         listen 8000 default_server;
         server_name _;
 
-        include http_locations.conf;
+        location /api/judge_server_heartbeat {
+            include api_proxy.conf;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
 
     server {
@@ -53,7 +61,7 @@ http {
         ssl_prefer_server_ciphers on;
         ssl_session_cache shared:SSL:10m;
 
-        include https_locations.conf;
+        include locations.conf;
     }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,6 @@ services:
       - POSTGRES_USER=onlinejudge
       - POSTGRES_PASSWORD=onlinejudge
       - JUDGE_SERVER_TOKEN=CHANGE_THIS
-      # - FORCE_HTTPS=1
     ports:
       - "0.0.0.0:80:8000"
       - "0.0.0.0:443:1443"

--- a/frontend/src/pages/admin/views/general/Dashboard.vue
+++ b/frontend/src/pages/admin/views/general/Dashboard.vue
@@ -62,15 +62,6 @@
             {{ https ? 'Enabled' : 'Disabled' }}
           </b-badge>
         </p>
-        <p>
-          force HTTPS:
-          <b-badge
-            :variant="forceHttps ? 'success' : 'danger'"
-            size="small"
-          >
-            {{ forceHttps ? 'Enabled' : 'Disabled' }}
-          </b-badge>
-        </p>
       </panel>
     </b-col>
 
@@ -230,9 +221,6 @@ export default {
     ...mapGetters(['profile', 'user', 'isSuperAdmin']),
     https () {
       return document.URL.slice(0, 5) === 'https'
-    },
-    forceHttps () {
-      return this.infoData.env.FORCE_HTTPS
     },
     browser () {
       const b = browserDetector(this.session.user_agent)


### PR DESCRIPTION
예전에 재민이형님이 올려주신 [보안테스트 결과](https://snyk.io/test/website-scanner/?test=210815_BiDcT2_9176c805959bebfff7f690f44a431a2b&utm_medium=referral&utm_source=webpagetest&utm_campaign=website-scanner)에서 부족한 헤더들을 추가해줬습니다.

- HSTS설정: [nginx공홈](https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/)을 참고하여 `nginx.config`에 추가하였습니다.  헤더와 함께 자동으로 HTTPS로 리다이렉트 되도록 설정해줬습니다.
- CSP설정: 이 [링크](https://content-security-policy.com/examples/nginx/)를 참고해서 CSP헤더 또한 추가하였습니다. 옵션으로 어떠한 URI는 허용한다 라고 정할 수 있는데, 아직 우리 프로젝트에 허용할 만한 사이트가 없는 거 같아 default로 설정해줬습니다.