### PR TITLE
Fix second mock competition issues in FE

### DIFF
--- a/frontend/src/pages/admin/views/general/Announcement.vue
+++ b/frontend/src/pages/admin/views/general/Announcement.vue
@@ -270,7 +270,7 @@ export default {
       if (id !== null) {
         if (this.contestID) {
           this.currentAnnouncementId = id
-          this.announcementDialogTitle = 'Edit Announcement'
+          this.announcementDialogTitle = 'Edit Clarification'
           this.contestAnnouncementList.find(item => {
             if (item.id === this.currentAnnouncementId) {
               this.announcement.title = item.title

--- a/frontend/src/pages/admin/views/general/Announcement.vue
+++ b/frontend/src/pages/admin/views/general/Announcement.vue
@@ -268,18 +268,33 @@ export default {
     openAnnouncementDialog (id) {
       this.showEditAnnouncementDialog = true
       if (id !== null) {
-        this.currentAnnouncementId = id
-        this.announcementDialogTitle = 'Edit Announcement'
-        this.announcementList.find(item => {
-          if (item.id === this.currentAnnouncementId) {
-            this.announcement.title = item.title
-            this.announcement.visible = item.visible
-            this.announcement.content = item.content
-            this.mode = 'edit'
-            return true
-          }
-          return false
-        })
+        if (this.contestID) {
+          this.currentAnnouncementId = id
+          this.announcementDialogTitle = 'Edit Announcement'
+          this.contestAnnouncementList.find(item => {
+            if (item.id === this.currentAnnouncementId) {
+              this.announcement.title = item.title
+              this.announcement.visible = item.visible
+              this.announcement.content = item.content
+              this.mode = 'edit'
+              return true
+            }
+            return false
+          })
+        } else {
+          this.currentAnnouncementId = id
+          this.announcementDialogTitle = 'Edit Announcement'
+          this.announcementList.find(item => {
+            if (item.id === this.currentAnnouncementId) {
+              this.announcement.title = item.title
+              this.announcement.visible = item.visible
+              this.announcement.content = item.content
+              this.mode = 'edit'
+              return true
+            }
+            return false
+          })
+        }
       } else {
         this.announcementDialogTitle = 'Create Announcement'
         this.announcement.title = ''

--- a/frontend/src/pages/oj/components/CodeMirror.vue
+++ b/frontend/src/pages/oj/components/CodeMirror.vue
@@ -118,6 +118,9 @@ export default {
     width: 100%;
     height: 100%;
   }
+  #codemirror::v-deep * {
+    font-family: Menlo, Monaco, Consolas,"Courier New", monospace
+  }
   #codemirror::v-deep .CodeMirror {
     height: 100% !important;
   }

--- a/frontend/src/pages/oj/components/CodeMirror.vue
+++ b/frontend/src/pages/oj/components/CodeMirror.vue
@@ -113,18 +113,18 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
   #codemirror {
     width: 100%;
     height: 100%;
   }
-  #codemirror::v-deep * {
+  .CodeMirror * {
     font-family: Menlo, Monaco, Consolas,"Courier New", monospace
   }
-  #codemirror::v-deep .CodeMirror {
+  .CodeMirror {
     height: 100% !important;
   }
-  #codemirror::v-deep .CodeMirror-scroll {
+  .CodeMirror-scroll {
     min-height: 300px;
     max-height: 100%;
   }

--- a/frontend/src/pages/oj/components/CodeMirror.vue
+++ b/frontend/src/pages/oj/components/CodeMirror.vue
@@ -118,10 +118,10 @@ export default {
     width: 100%;
     height: 100%;
   }
-  .CodeMirror {
+  #codemirror::v-deep .CodeMirror {
     height: 100% !important;
   }
-  .CodeMirror-scroll {
+  #codemirror::v-deep .CodeMirror-scroll {
     min-height: 300px;
     max-height: 100%;
   }

--- a/frontend/src/pages/oj/views/announcement/AnnouncementList.vue
+++ b/frontend/src/pages/oj/views/announcement/AnnouncementList.vue
@@ -81,10 +81,10 @@ export default {
         await this.getAnnouncementList()
       }
     },
-    async getAnnouncementList (page = 1) {
+    async getAnnouncementList () {
       this.btnLoading = true
       try {
-        const res = await api.getAnnouncementList((page - 1) * this.limit, 250)
+        const res = await api.getAnnouncementList(0, 250)
         this.btnLoading = false
         this.announcements = res.data.data.results
         this.total = res.data.data.total

--- a/frontend/src/pages/oj/views/announcement/AnnouncementList.vue
+++ b/frontend/src/pages/oj/views/announcement/AnnouncementList.vue
@@ -40,7 +40,6 @@ export default {
     return {
       perPage: 10,
       currentPage: 1,
-      limit: 10,
       total: 10,
       btnLoading: false,
       announcements: [],
@@ -85,7 +84,7 @@ export default {
     async getAnnouncementList (page = 1) {
       this.btnLoading = true
       try {
-        const res = await api.getAnnouncementList((page - 1) * this.limit, this.limit)
+        const res = await api.getAnnouncementList((page - 1) * this.limit, 250)
         this.btnLoading = false
         this.announcements = res.data.data.results
         this.total = res.data.data.total

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -75,7 +75,7 @@
 
         <b-navbar-nav class="ml-auto">
           <b-nav-item v-if="statusVisible">
-            <template v-if="!this.contestID || (this.contestID && OIContestRealTimePermission)">
+            <template>
               <div @click.stop="$refs.sidebar.onMySubmissionClicked({ID:submissionId})">
                 <b-badge
                   class="statusBadge"
@@ -85,15 +85,6 @@
                   {{ submissionStatus.text }}
                 </b-badge>
               </div>
-            </template>
-            <template v-else-if="this.contestID && !OIContestRealTimePermission">
-              <b-badge
-                class="statusBadge"
-                variant="light"
-              >
-                <b-icon id="badgeIcon" icon="circle-fill" class="green" scale="0.9"/>
-                Submitted Succesfully
-              </b-badge>
             </template>
           </b-nav-item>
           <b-nav-item v-else-if="problem.my_status === 0">
@@ -124,12 +115,12 @@
               <b-icon icon="arrow-clockwise" scale="1.1"/>
             </b-button>
           </b-nav-item>
-          <b-nav-item>
+          <!-- <b-nav-item>
             <b-button class="btn">
               <b-icon icon="play" scale="1.4"/>
               Run
             </b-button>
-          </b-nav-item>
+          </b-nav-item> -->
           <b-nav-item>
             <b-button class="btn-submit"
               :disabled="(contestID && problemSubmitDisabled) || submitted"
@@ -657,7 +648,7 @@ export default {
 
       p {
         font-size: 15px;
-        margin-bottom: 40px;
+        // margin-bottom: 40px;
       }
 
       .description-io {

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -330,7 +330,7 @@ export default {
         let preferredLanguage = problem.languages[0]
         const res3 = await api.getUserInfo(userId)
 
-        const lang = res3.data.data && res3.data.data.language
+        const lang = res3.data.data?.language
         if (lang !== null) {
           if (problem.languages.includes(lang)) {
             preferredLanguage = lang

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -339,7 +339,7 @@ export default {
         let preferredLanguage = problem.languages[0]
         const res3 = await api.getUserInfo(userId)
 
-        const lang = res3.data.data.language
+        const lang = res3.data.data && res3.data.data.language
         if (lang !== null) {
           if (problem.languages.includes(lang)) {
             preferredLanguage = lang

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -15,11 +15,11 @@
         </b-navbar-brand>
 
         <b-navbar-nav v-if="$route.name && $route.name.indexOf('contest') != -1">
-          <b-nav-item to="#">Contests</b-nav-item>
+          <b-nav-item to="/contest">Contests</b-nav-item>
           <b-nav-item>
             <b-icon icon="chevron-right"/>
           </b-nav-item>
-          <b-nav-item to="#">{{problem.contest_name}}</b-nav-item>
+          <b-nav-item :to="'/contest/' + this.contestID">{{problem.contest_name}}</b-nav-item>
           <b-nav-item>
             <b-icon icon="chevron-right"/>
           </b-nav-item>

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -720,6 +720,7 @@ export default {
         margin: 0;
         padding: 0;
         flex: 1 1 auto;
+        overflow: auto;
       }
 
       #io {

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -522,6 +522,8 @@ export default {
   },
   watch: {
     async '$route' () {
+      this.statusVisible = false
+      this.code = ''
       await this.init()
     },
     contestEnded: function () {

--- a/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
+++ b/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
@@ -292,7 +292,7 @@ export default {
       const func = this.contestID ? 'getContestSubmissionList' : 'getSubmissionList'
 
       // offset, limit, params
-      const result = await api[func](0, 1000, params)
+      const result = await api[func](0, 100, params)
       const data = result.data.data
       const submissions = data.results.map(v => {
         var info = {


### PR DESCRIPTION
2차 모의대회에서 발생한 프론트엔드 이슈 해결
Fix second mock competition issues in frontend
1. admin - Announcement.vue : clarrification edit이 되지 않는 문제 해결 (@DailyPS )
2. admin - problem.vue : Problem edit에서 불러온 테스트케이스가 50mb를 넘을 시 테스트케이스를 렌더링하거나 새로 업로드하지 않도록 변경 (@cranemont ) 
3. codemirror.vue : 코드미러 사이즈가 꽉 채워지지 않는 이슈, 폰트 적용 안되는 이슈 해결 (@jimin9038 )
4. oj - AnnouncementList.vue : announcement가 10개 이상 안 불러와지는 이슈 해결 (@SOLBI1028 )
5. oj - problem.vue : 일반 유저의 경우 이전 제출 결과가 보이지 않는 이슈 해결 (@Jeongcc )
6. oj - problem.vue : problem sidebar를 통해 problem 이동시 code 및 태그가 초기화되지 않는 이슈 해결  (@Kohminchae )
7. oj - problem.vue : Fix problem infinite loading when not logined (@jimin9038 )
8. oj - problem.vue : Change path of contest list and contest title (@minseo999 )

