### PR TITLE
Fix: Codemirror not rendered issue when clicking recent submission

### DIFF
--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -76,7 +76,7 @@
         <b-navbar-nav class="ml-auto">
           <b-nav-item v-if="statusVisible">
             <template>
-              <div @click.stop="$refs.sidebar.onMySubmissionClicked({ID:submissionId})">
+              <div @click.stop="onMySubmissionClicked">
                 <b-badge
                   class="statusBadge"
                   variant="light"
@@ -464,6 +464,11 @@ export default {
       } else {
         await submitFunc(data, true)
       }
+    },
+    async onMySubmissionClicked () {
+      await this.$refs.sidebar.onMySubmissionClicked({ ID: this.submissionId })
+      await this.$nextTick()
+      this.$refs.sidebar.codemirror_key += 1
     }
   },
   computed: {


### PR DESCRIPTION
![image (8)](https://user-images.githubusercontent.com/73051219/140681169-92d00afc-61c5-4691-93a8-3a8dfe09e042.png)
![image (9)](https://user-images.githubusercontent.com/73051219/140681173-36a67bc0-cf04-448f-8601-c74f2ada8ebb.png)

Recent Submission 을 눌러 최근 제출 기록을 보려고 할 때 Codemirror 렌더링이 안 되는 문제 해결 (위 사진 참고)