### PR TITLE
Add IpAddressInfoAPI in /conf

### DIFF
--- a/backend/conf/tests.py
+++ b/backend/conf/tests.py
@@ -183,3 +183,13 @@ class DashboardInfoAPITest(APITestCase):
         resp = self.client.get(self.url)
         self.assertSuccess(resp)
         self.assertEqual(resp.data["data"]["user_count"], 1)
+
+
+class IpAddressInfoAPITest(APITestCase):
+    def setUp(self):
+        self.url = self.reverse("ip_address_info_api")
+        self.create_admin()
+
+    def test_get_ip(self):
+        resp = self.client.get(self.url)
+        self.assertSuccess(resp)

--- a/backend/conf/urls/admin.py
+++ b/backend/conf/urls/admin.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from ..views import SMTPAPI, JudgeServerAPI, WebsiteConfigAPI, TestCasePruneAPI, SMTPTestAPI
+from ..views import SMTPAPI, JudgeServerAPI, WebsiteConfigAPI, TestCasePruneAPI, SMTPTestAPI, IpAddressInfoAPI
 from ..views import ReleaseNotesAPI, DashboardInfoAPI
 
 urlpatterns = [
@@ -11,4 +11,5 @@ urlpatterns = [
     path("prune_test_case/", TestCasePruneAPI.as_view(), name="prune_test_case_api"),
     path("versions/", ReleaseNotesAPI.as_view(), name="get_release_notes_api"),
     path("dashboard_info/", DashboardInfoAPI.as_view(), name="dashboard_info_api"),
+    path("ip_info/", IpAddressInfoAPI.as_view(), name="ip_address_info_api"),
 ]

--- a/backend/conf/views.py
+++ b/backend/conf/views.py
@@ -289,3 +289,16 @@ class DashboardInfoAPI(APIView):
             "today_submission_count": today_submission_count,
             "judge_server_count": judge_server_count
         })
+
+
+class IpAddressInfoAPI(APIView):
+    @swagger_auto_schema(operation_description="Get IpAddressInfo")
+    def get(self, request):
+        x_forwareded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if x_forwareded_for:
+            ip = x_forwareded_for.split(",")[0]
+        else:
+            ip = request.META.get("REMOTE_ADDR")
+        return self.success({
+            "ip": ip
+        })

--- a/frontend/src/pages/admin/api.js
+++ b/frontend/src/pages/admin/api.js
@@ -323,6 +323,9 @@ export default {
     return ajax('admin/upload_file/', 'post', {
       data
     })
+  },
+  getIPAddress () {
+    return ajax('admin/ip_info/', 'get')
   }
 }
 

--- a/frontend/src/pages/admin/views/general/Dashboard.vue
+++ b/frontend/src/pages/admin/views/general/Dashboard.vue
@@ -34,8 +34,8 @@
             </b-form-group>
             <b-form-group label-cols="3"
             label = "IP:">
-              <label class=“mr-sm-2”>IP:</label>
-              <span>{{ session.ip }}</span>
+              <label class=“mr-sm-2”></label>
+              <span>{{ ip }}</span>
             </b-form-group>
             <b-form-group label-cols="3"
             label = "OS">
@@ -172,7 +172,8 @@ export default {
       activeNames: [1],
       session: {},
       loadingReleases: true,
-      releases: []
+      releases: [],
+      ip: ''
     }
   },
   async mounted () {
@@ -185,6 +186,12 @@ export default {
     try {
       const resp = await api.getSessions()
       this.parseSession(resp.data.data)
+    } catch (err) {
+    }
+
+    try {
+      const resp = await api.getIPAddress()
+      this.ip = resp.data.data.ip
     } catch (err) {
     }
 


### PR DESCRIPTION
Admin 페이지에서 ip를 받아올 수 있도록 IpAddressInfoAPI 를 backend 폴더에 추가하였습니다.
HTTP_X_FORWARDED_FOR을 사용해 클라이언트 ip 주소를 받아오도록 일단 설정했는데, Notion 2022-01-03 Backend 회의록에 IP API Notion 페이지 링크를 걸어두었으니 참고해주시면 감사하겠습니다!
혹시 수정할 부분이 있으면 언제든 알려주시면 감사하겠습니다!