### PR TITLE
Fix code_template error

### DIFF
--- a/backend/judge/dispatcher.py
+++ b/backend/judge/dispatcher.py
@@ -157,7 +157,8 @@ class JudgeDispatcher(DispatcherBase):
 
         if language in self.problem.template:
             template = parse_problem_template(self.problem.template[language])
-            code = f"{template['prepend']}\n{self.submission.code}\n{template['append']}"
+            parse_code = parse_problem_template(self.submission.code)
+            code = f"{template['prepend']}\n{parse_code['template']}\n{template['append']}"
         else:
             code = self.submission.code
 


### PR DESCRIPTION
#197 에러 수정했습니다
(backend/judge/dispatcher.py 에서 template['append'], template['prepend'] 부분과 self.submission.code 의 중복 현상 -> self.submission.code에서 template 부분만 parsing)
관련문서는 백엔드 회의록 2021.01.06에 있습니다!

Closes #197