### PR TITLE
Configure debugging in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,16 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: Django",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceFolder}/backend/manage.py",
-            "args": [
-                "runserver"
-            ],
-            "django": true
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Django",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/manage.py",
+      "args": [
+        "runserver",
+        "--noreload"
+      ],
+      "django": true
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,28 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Vue.js: Chrome",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}/frontend/src",
+      "breakOnLoad": true,
+      "sourceMapPathOverrides": {
+        "webpack:///src/*": "${webRoot}/*"
+      }
+    },
+    {
+      "name": "Vue.js: Edge",
+      "type": "msedge",
+      "request": "launch",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}/frontend/src",
+      "breakOnLoad": true,
+      "sourceMapPathOverrides": {
+        "webpack:///src/*": "${webRoot}/*"
+      }
+    },
+    {
       "name": "Python: Django",
       "type": "python",
       "request": "launch",

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -35,6 +35,7 @@ module.exports = {
     }
   },
   configureWebpack: {
+    devtool: 'source-map',
     resolve: {
       extensions: ['.js', '.vue', '.json'],
       alias: {


### PR DESCRIPTION
VSCode에서 Python(Django)과 Javascript(Vue.js)를 debugging하는 환경을 구성한다.
closes #258 

### Backend
원하는 지점에 breakpoint를 걸고 F5를 눌러(또는 측면 메뉴에서 'Run and Debug' 선택) debugging을 시작한다.

### Frontend
원하는 지점에 breakpoint를 걸고 `yarn serve`로 서버를 구동한 후, Backend와 같은 절차로 debugging한다.
Chrome 또는 Edge 브라우저를 사용한다. ([Vue.js devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)를 함께 사용하는 것을 권장합니다)

![Screenshot_20220116-170404_Chrome](https://user-images.githubusercontent.com/19747913/149652176-c69daaef-21cc-4586-8037-e846f942b885.jpg)