### PR TITLE
hotfix: For backward compatibility before PR 272

### DIFF
--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -433,7 +433,14 @@ export default {
       problem.languages = problem.languages.sort()
       this.problem = problem
 
-      const precode = storage.get(buildProblemCodeKey(this.problemID, this.contestID))
+      let precode = storage.get(buildProblemCodeKey(this.problemID, this.contestID))
+
+      // For Backward compatibility before Github pr #272
+      if (precode && typeof precode.code === 'string') {
+        storage.remove(buildProblemCodeKey(this.problemID, this.contestID))
+        precode = null
+      }
+
       if (precode) {
         this.language = precode.language
         this.code = precode.code[this.language]


### PR DESCRIPTION
#272 에서 localstorage에 problem code가 저장되는 구조가 바뀌었는데, 이로 인해 예전 제출 기록이 있는 문제의 경우 제출 등이 안되는 문제가 발생하여 호환성을 위해 코드를 추가하였습니다. (예전 구조의 경우 삭제하도록 하였습니다.)